### PR TITLE
Added shower startpoint correction post-processor and reco particle attributes

### DIFF
--- a/spine/data/out/particle.py
+++ b/spine/data/out/particle.py
@@ -196,11 +196,19 @@ class RecoParticle(ParticleBase, RecoBase):
         (M) List of indexes of PPN points associated with this particle
     ppn_points : np.ndarray
         (M, 3) List of PPN points tagged to this particle
+    vertex_distance: float
+        Set-to-point distance between all particle points and the parent
+        interaction vertex. (untis of cm)
+    shower_split_angle: float
+        Estimate of the opening angle of the shower. If particle is not a
+        shower, then this is set to -1. (units of degrees)
     """
     pid_scores: np.ndarray = None
     primary_scores: np.ndarray = None
     ppn_ids: np.ndarray = None
     ppn_points: np.ndarray = None
+    vertex_distance = -1.
+    shower_split_angle = -1.
 
     # Fixed-length attributes
     _fixed_length_attrs = {

--- a/spine/data/out/particle.py
+++ b/spine/data/out/particle.py
@@ -207,8 +207,8 @@ class RecoParticle(ParticleBase, RecoBase):
     primary_scores: np.ndarray = None
     ppn_ids: np.ndarray = None
     ppn_points: np.ndarray = None
-    vertex_distance = -1.
-    shower_split_angle = -1.
+    vertex_distance: float = -1.
+    shower_split_angle: float = -1.
 
     # Fixed-length attributes
     _fixed_length_attrs = {

--- a/spine/post/reco/shower.py
+++ b/spine/post/reco/shower.py
@@ -335,7 +335,7 @@ class ShowerStartpointCorrectionProcessor(PostBase):
         guess : np.ndarray
             (3, ) array of the corrected shower startpoint.
         """
-        track_points = [p.points for p in ia.particles if p.semantic_type == TRACK_SHP and p.is_primary]
+        track_points = [p.points for p in ia.particles if p.shape == TRACK_SHP and p.is_primary]
         if track_points == []:
             return shower_p.start_point
         

--- a/spine/post/reco/shower.py
+++ b/spine/post/reco/shower.py
@@ -171,12 +171,12 @@ class ShowerMultiArmCheck(PostBase):
     name = 'shower_multi_arm_check'
     aliases = ['shower_multi_arm']
     
-    def __init__(self, threshold=0.25, min_samples=20, eps=0.02):
+    def __init__(self, threshold=70, min_samples=20, eps=0.02):
         """Specify the threshold for the number of arms of showers.
 
         Parameters
         ----------
-        threshold : float, default 0.25
+        threshold : float, default 70 (deg)
             If the electron shower's leading and subleading angle are
             separated by more than this, the shower is considered to be
             invalid and its PID will be changed to PHOT_PID.
@@ -234,7 +234,7 @@ class ShowerMultiArmCheck(PostBase):
         -------
         max_angle : float
             Maximum angle between the mean cluster direction vectors 
-            of the shower points.
+            of the shower points (degrees)
         """
         points = p.points
         depositions = p.depositions
@@ -276,9 +276,10 @@ class ShowerMultiArmCheck(PostBase):
         vecs = np.vstack(vecs)
         cos_dist = cosine_similarity(vecs)
         # max_angle ranges from 0 (parallel) to 2 (antiparallel)
-        max_angle = (np.abs(1.0 - cos_dist)).max()
+        max_angle = np.clip((1.0 - cos_dist).max(), a_min=0, a_max=2)
+        max_angle_deg = np.rad2deg(np.arccos(1 - max_angle))
         # counts = counts[1:]
-        return max_angle
+        return max_angle_deg
     
     
 class ShowerStartpointCorrectionProcessor(PostBase):

--- a/spine/post/reco/tracking.py
+++ b/spine/post/reco/tracking.py
@@ -135,7 +135,8 @@ class TrackValidityProcessor(PostBase):
                 if p.shape == TRACK_SHP and p.is_primary:
                     # Check vertex attachment
                     dist = np.linalg.norm(p.points - ia.vertex, axis=1)
-                    if dist.min() > self.threshold:
+                    p.vertex_dist = dist.min()
+                    if p.vertex_dist > self.threshold:
                         p.is_primary = False
                     # Check if track is small and within radius from vertex
                     if self.check_small_track:

--- a/spine/post/reco/tracking.py
+++ b/spine/post/reco/tracking.py
@@ -135,8 +135,8 @@ class TrackValidityProcessor(PostBase):
                 if p.shape == TRACK_SHP and p.is_primary:
                     # Check vertex attachment
                     dist = np.linalg.norm(p.points - ia.vertex, axis=1)
-                    p.vertex_dist = dist.min()
-                    if p.vertex_dist > self.threshold:
+                    p.vertex_distance = dist.min()
+                    if p.vertex_distance > self.threshold:
                         p.is_primary = False
                     # Check if track is small and within radius from vertex
                     if self.check_small_track:


### PR DESCRIPTION
The shower startpoint correction post-processor (`showerstart_correction_processor`) re-computes the shower start to a point in shower closest to the estimated reco vertex. 

Also added two new attributes to `RecoParticle`:
 1. `vertex_distance`: the closest distance between all points of a `RecoParticle` object and `RecoInteraction.vertex`. 
 2. `shower_split_angle`: the estimate of the angular separation between the "two major directions". Used for rejecting $\pi^0 -> \gamma \gamma$ decays in $\nu_e$ selection. The `shower_split_angle` is computed using the following procedure:
    * Compute the displacement from the vertex to all shower points. 
    * Normalize the displacement vectors to the unit sphere. This gives a distribution of "directions" on the unit sphere, with the sphere center as the vertex. 
    * Cluster the unit vectors using DBSCAN with cosine distance. 
    * The `shower_split_angle` is defined as the maximum angle between the mean direction vectors of each DBSCAN cluster on the unit sphere. 