### PR TITLE
Add track de/dx and ability to fill them

### DIFF
--- a/spine/data/out/particle.py
+++ b/spine/data/out/particle.py
@@ -217,6 +217,8 @@ class RecoParticle(ParticleBase, RecoBase):
         interaction vertex position in cm
     start_dedx : float
         dE/dx around a user-defined neighborhood of the start point in MeV/cm
+    end_dedx : float
+        dE/dx around a user-defined neighborhood of the end point in MeV/cm
     start_straightness : float
         Explained variance ratio of the beginning of the particle
     directional_spread : float
@@ -231,6 +233,7 @@ class RecoParticle(ParticleBase, RecoBase):
     ppn_points: np.ndarray = None
     vertex_distance: float = -1.
     start_dedx: float = -1.
+    end_dedx: float = -1.
     start_straightness: float = -1.
     directional_spread: float = -1.
     axial_spread: float = -np.inf

--- a/spine/post/reco/topology.py
+++ b/spine/post/reco/topology.py
@@ -22,7 +22,7 @@ class ParticleStartDEDXProcessor(PostBase):
     name = 'start_dedx'
 
     # Aliases for the post-processor
-    aliases = ('end_dedx',)
+    aliases = ('end_dedx','start_dedx_track')
 
     # List of recognized dE/dx computation modes
     _modes = ('default', 'direction')

--- a/spine/post/reco/topology.py
+++ b/spine/post/reco/topology.py
@@ -21,11 +21,14 @@ class ParticleStartDEDXProcessor(PostBase):
     # Name of the post-processor (as specified in the configuration)
     name = 'start_dedx'
 
+    # Aliases for the post-processor
+    aliases = ('end_dedx',)
+
     # List of recognized dE/dx computation modes
     _modes = ('default', 'direction')
 
     def __init__(self, radius=3.0, anchor=False, mode='direction',
-                 include_pids=(PHOT_PID, ELEC_PID), include_secondary=False):
+                 include_pids=(PHOT_PID, ELEC_PID), include_secondary=False, use_point='start'):
         """Store the particle start dE/dx reconstruction parameters.
 
         Parameters
@@ -41,6 +44,8 @@ class ParticleStartDEDXProcessor(PostBase):
             Particle species to compute the start dE/dx for
         include_secondary : bool, default False
             If `True`, computes the start dE/dx for secondary particles
+        use_point : str, default 'start'
+            Point to use for dE/dx calculation. Can be 'start' or 'end'
         """
         # Initialize the parent class
         super().__init__('particle', 'reco')
@@ -56,6 +61,7 @@ class ParticleStartDEDXProcessor(PostBase):
         self.anchor = anchor
         self.include_pids = include_pids
         self.include_secondary = include_secondary
+        self.use_point = use_point
 
         # If the method involves the direction, must run the direction PP
         if mode == 'direction':
@@ -79,19 +85,30 @@ class ParticleStartDEDXProcessor(PostBase):
             if part.pid not in self.include_pids:
                 continue
 
+            # Fetch the appropriate reference point
+            if self.use_point == 'start':
+                ref_point = part.start_point
+            elif self.use_point == 'end':
+                ref_point = part.end_point
+            else:
+                raise ValueError(f"Invalid use_point: {self.use_point}")
+
             # Compute the particle start dE/dx
             if self.mode == 'default':
                 # Use all depositions within a radius of the particle start
-                part.start_dedx = cluster_dedx(
-                        part.points, part.depositions, part.start_point,
+                dedx = cluster_dedx(
+                        part.points, part.depositions, ref_point,
                         max_dist=self.radius, anchor=self.anchor)
 
             else:
                 # Use the particle direction estimate as a guide
-                part.start_dedx = cluster_dedx_dir(
-                        part.points, part.depositions, part.start_point,
+                dedx = cluster_dedx_dir(
+                        part.points, part.depositions, ref_point,
                         part.start_dir, max_dist=self.radius,
                         anchor=self.anchor)[0]
+
+            # Store the dE/dx
+            setattr(part, f'{self.use_point}_dedx', dedx)
 
 
 class ParticleStartStraightnessProcessor(PostBase):


### PR DESCRIPTION
Slight modifications to storing dedx of tracks at start and end. Useful for dirt selection.

```
...
post:
  start_dedx_track:
    radius: 4.0
    anchor: false
    mode: default
    include_pids: [2, 3, 4] #muon, pion, proton
    use_point: start
  end_dedx:
    radius: 4.0
    anchor: false
    mode: default
    include_pids: [2, 3, 4] #muon, pion, proton
    use_point: end
```
Radius based on dirt studies (see plot)

![image](https://github.com/user-attachments/assets/b0184164-e2bf-4248-9cab-01acfcdc14ea)
![image](https://github.com/user-attachments/assets/28caf0e9-879c-4cbd-b364-572766e80fc7)

