### PR TITLE
Fixes bug for computing gradient

### DIFF
--- a/spine/utils/tracking.py
+++ b/spine/utils/tracking.py
@@ -195,9 +195,10 @@ def get_track_deposition_gradient(coordinates: nb.float32[:,:],
     seg_dedxs = seg_dedxs[valid_index]
     seg_rrs = seg_rrs[valid_index]
 
-    # Compute the dE/dx gradient
-    gradient = np.cov(seg_rrs, seg_dedxs)[0,1]/np.std(seg_rrs)**2 \
-            if np.std(seg_rrs) > 0. else 0.
+    # Compute the dE/dx gradient = Cov(x,y) / Var(x)
+    cov = np.cov(seg_rrs, seg_dedxs)
+    gradient = cov[0,1]/cov[0,0] \
+            if cov[0,0] > 0. else 0.
 
     return gradient, seg_dedxs, seg_rrs, seg_lengths
 


### PR DESCRIPTION
Replaces #96 on DLP

std(x) has a prefactor of 1/N, whereas cov(x,y) has a prefactor of 1/N-1. So we should use the covariance[0,0] to get the variance of x directly.

```
cov[0,1]/cov[0,0],cov[0,1]/np.std(df['seg_rrs'][ind])**2
>>> (np.float64(0.018677554097208945), np.float64(0.020375516343523768))
```