### PR TITLE
Cathode crosser PR: Bug fixes for cdist and already matched particles

### DIFF
--- a/spine/data/out/particle.py
+++ b/spine/data/out/particle.py
@@ -196,6 +196,13 @@ class ParticleBase:
     def p(self, p):
         pass
 
+    def unmatch(self):
+        """
+        Unmatch the particle from its reco or truth particle match.
+        """
+        self.match_ids = []
+        self.is_matched = False
+
 
 @dataclass(eq=False)
 @inherit_docstring(RecoBase, ParticleBase)

--- a/spine/post/reco/cathode_cross.py
+++ b/spine/post/reco/cathode_cross.py
@@ -5,6 +5,7 @@ import numpy as np
 from spine.data import RecoInteraction, TruthInteraction
 
 from spine.math.distance import cdist, farthest_pair
+from scipy.spatial.distance import cdist as scipy_cdist
 
 from spine.utils.globals import TRACK_SHP
 from spine.utils.geo import Geometry
@@ -188,7 +189,7 @@ class CathodeCrosserProcessor(PostBase):
                     # Check if the two particles stop at roughly the same
                     # position in the plane of the cathode
                     compat = True
-                    dist_mat = cdist(
+                    dist_mat = scipy_cdist(
                             end_points_i[:, caxes], end_points_j[:, caxes])
                     argmin = np.argmin(dist_mat)
                     pair_i, pair_j = np.unravel_index(argmin, (2, 2))
@@ -270,6 +271,10 @@ class CathodeCrosserProcessor(PostBase):
         points_key = 'points' if not truth else self.truth_point_key
         particles = data[part_key]
         if idx_j is not None:
+            # Unmatch the particles from their interactions
+            particles[idx_i].unmatch()
+            particles[idx_j].unmatch()
+
             # Merge particles
             int_id_i = particles[idx_i].interaction_id
             int_id_j = particles[idx_j].interaction_id

--- a/spine/post/reco/cathode_cross.py
+++ b/spine/post/reco/cathode_cross.py
@@ -1,13 +1,14 @@
 """Cathode crossing identification + merging module."""
 
 import numpy as np
-from scipy.spatial.distance import cdist
 
 from spine.data import RecoInteraction, TruthInteraction
 
+from spine.math.distance import cdist, farthest_pair
+from scipy.spatial.distance import cdist as scipy_cdist
+
 from spine.utils.globals import TRACK_SHP
 from spine.utils.geo import Geometry
-from spine.utils.numba_local import farthest_pair
 from spine.utils.gnn.cluster import cluster_direction
 
 from spine.post.base import PostBase
@@ -81,7 +82,6 @@ class CathodeCrosserProcessor(PostBase):
             keys['points'] = True
         if run_mode != 'reco':
             keys[truth_point_mode] = True
-
         keys['meta'] = True #Needed to find shift in the cathode
         self.update_keys(keys)
 
@@ -191,7 +191,7 @@ class CathodeCrosserProcessor(PostBase):
                     # Check if the two particles stop at roughly the same
                     # position in the plane of the cathode
                     compat = True
-                    dist_mat = cdist(
+                    dist_mat = scipy_cdist(
                             end_points_i[:, caxes], end_points_j[:, caxes])
                     argmin = np.argmin(dist_mat)
                     pair_i, pair_j = np.unravel_index(argmin, (2, 2))
@@ -213,7 +213,7 @@ class CathodeCrosserProcessor(PostBase):
                     # If compatible, merge
                     if compat:
                         # Merge particle and adjust positions
-                        self.adjust_positions(data, ci, dx_res,cj, truth=pi.is_truth)
+                        self.adjust_positions(data, ci,dx_res, cj, truth=pi.is_truth)
 
                         # Update the candidate list to remove matched particle
                         candidate_ids[j:-1] = candidate_ids[j+1:] - 1
@@ -262,7 +262,6 @@ class CathodeCrosserProcessor(PostBase):
             Index of a matched cathode crosser fragment
         truth : bool, default False
             If True, adjust truth object positions
-
         Results
         -------
         np.ndarray


### PR DESCRIPTION
Based on #99 DLP

spine cdist does not work in 2D. Also, already matched particles complain when attempting to merge. So go ahead and unmatch them first. This only applies on existing h5 files where match has been ran.